### PR TITLE
Add rfi mask to dedisperse

### DIFF
--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -90,6 +90,7 @@ def get_nbits(dtype):
     else:
         raise RuntimeError(f"dtype={dtype} not supported")
 
+
 # OK so if it's a filterbank it SHOULD have HEADER_START and HEADER_END
 # I think I was testing it on one that wasn't properly written, so I had to
 # add them in
@@ -122,16 +123,17 @@ def get_fmin_fmax_invert(header):
     """Calculate band edges and whether the band is inverted from a filterbank header
     Returns fmin, fmax, inverted"""
 
-    if header['foff'] < 0:
+    if header["foff"] < 0:
         fmax = header["fch1"] - header["foff"] / 2
-        fmin = fmax + header['nchans'] * header["foff"]
+        fmin = fmax + header["nchans"] * header["foff"]
         invert = True
     else:
         fmin = header["fch1"] - header["foff"] / 2
-        fmax = fmin + header['nchans'] * header["foff"]
+        fmax = fmin + header["nchans"] * header["foff"]
         invert = False
 
     return fmin, fmax, invert
+
 
 ################################################################################
 # MASKING FUNCTIONS:
@@ -174,7 +176,9 @@ class Mask:
         # original rfimask has this as an array, convert to set if necessary
         self.mask_zap_ints = set(rfimask.mask_zap_ints)
         if invertband:
-            self.mask_zap_chans = set(list(self.nchan - 1 - np.array(list(rfimask.mask_zap_chans))))
+            self.mask_zap_chans = set(
+                list(self.nchan - 1 - np.array(list(rfimask.mask_zap_chans)))
+            )
         else:
             self.mask_zap_chans = rfimask.mask_zap_chans
         # original rfimask has this as a list of arrays, convert to set if necessary
@@ -335,7 +339,19 @@ def clip(
             chan_running_avg=chan_running_avg,
         )
 
-def clip_mask_subbase_gulp(nint, ptsperint, data, running_dict, clipsig, droptotsig, gulp, maxDT, current_int, mask):
+
+def clip_mask_subbase_gulp(
+    nint,
+    ptsperint,
+    data,
+    running_dict,
+    clipsig,
+    droptotsig,
+    gulp,
+    maxDT,
+    current_int,
+    mask,
+):
     """Clip, mask and subtract the running_avg from a gulp"""
     for interval in range(nint):
         try:
@@ -362,7 +378,19 @@ def clip_mask_subbase_gulp(nint, ptsperint, data, running_dict, clipsig, droptot
         data[slc, list(mask.mask_zap_chans_per_int[current_int])] = 0
         current_int += 1
 
-def clip_subbase_gulp(nint, ptsperint, data, running_dict, clipsig, droptotsig, gulp, maxDT, current_int, *args):
+
+def clip_subbase_gulp(
+    nint,
+    ptsperint,
+    data,
+    running_dict,
+    clipsig,
+    droptotsig,
+    gulp,
+    maxDT,
+    current_int,
+    *args,
+):
     """Same as clip_mask_subbase_gulp but no mask"""
     for interval in range(nint):
         try:
@@ -387,6 +415,7 @@ def clip_subbase_gulp(nint, ptsperint, data, running_dict, clipsig, droptotsig, 
 
         data[slc, :] -= running_dict["chan_running_avg"]
         current_int += 1
+
 
 ################################################################################
 # DM FUNCTIONS:
@@ -433,9 +462,7 @@ def get_fs(fmin, fmax, nchans, type="center", invertband=True, **kwargs):
     if type == "lower":
         fs = np.linspace(fmin, fmax, nchans, endpoint=False, **kwargs)
     elif type == "center":
-        fs = np.linspace(
-            fmin + df / 2, fmax - df / 2, nchans, endpoint=True, **kwargs
-        )
+        fs = np.linspace(fmin + df / 2, fmax - df / 2, nchans, endpoint=True, **kwargs)
     elif type == "upper":
         fs = np.linspace(fmin + df, fmax, nchans, endpoint=True, **kwargs)
     else:
@@ -489,13 +516,14 @@ def shift_and_stack(data, shifts, prev_array, maxDT):
 
     return prev_array, mid_array, end_array
 
+
 def approx_size_shifted_arrays(data, maxDT):
     nbytes = get_nbits(data.dtype) // 4
     ilength, nchans = data.shape
     prev_sz = nbytes * maxDT * nchans
     end_sz = prev_sz
     mid_sz = nbytes * (ilength - maxDT) * nchans
-    return 2*prev_sz + mid_sz + end_sz
+    return 2 * prev_sz + mid_sz + end_sz
 
 
 def get_gulp(nsamples, ptsperint, maxDT, mingulp, desired_gulp, verbose=False):
@@ -594,7 +622,11 @@ if __name__ == "__main__":
 
     g = parser.add_mutually_exclusive_group(required=True)
     g.add_argument(
-        "-d", "--dm", type=float, default=0, help="DM (cm-3pc) to dedisperse to, must be positive"
+        "-d",
+        "--dm",
+        type=float,
+        default=0,
+        help="DM (cm-3pc) to dedisperse to, must be positive",
     )
     g.add_argument(
         "-t",
@@ -667,23 +699,32 @@ if __name__ == "__main__":
         print(message)
 
     if args.verbosity > 0:
+
         def verbose_message1(message):
             print(message)
+
     else:
+
         def verbose_message1(message):
             pass
 
     if args.verbosity > 1:
+
         def verbose_message2(message):
             print(message)
+
     else:
+
         def verbose_message2(message):
             pass
 
     if args.verbosity > 2:
+
         def verbose_message3(message):
             print(message)
+
     else:
+
         def verbose_message3(message):
             pass
 
@@ -691,14 +732,21 @@ if __name__ == "__main__":
     if args.clipsig or args.droptotsig or args.mask:
         if not_zero_or_none(args.mask):
             "Preprocess is: clipping/computing running averages, subtracting baseline, masking"
+
             def preprocess(*args, **kwargs):
                 clip_mask_subbase_gulp(*args, **kwargs)
+
         else:
             "Preprocess is: clipping/computing running averages, subtracting baseline, NOT masking"
+
             def preprocess(*args, **kwargs):
                 clip_subbase_gulp(*args, **kwargs)
+
     else:
-        verbose_message0("Preprocess is: NOT clipping/computing running averages, NOT subtracting baseline, NOT masking")
+        verbose_message0(
+            "Preprocess is: NOT clipping/computing running averages, NOT subtracting baseline, NOT masking"
+        )
+
         def preprocess(*args, **kwargs):
             pass
 
@@ -771,7 +819,9 @@ if __name__ == "__main__":
         f"Minimum gulp is {mingulp} time samples (= {mingulp / ptsperint:.1f} intervals)",
     )
 
-    gulp, nsamp_cut_off = get_gulp(nsamples, ptsperint, maxDT, mingulp, args.gulp, verbose=(args.verbosity >= 2))
+    gulp, nsamp_cut_off = get_gulp(
+        nsamples, ptsperint, maxDT, mingulp, args.gulp, verbose=(args.verbosity >= 2)
+    )
     verbose_message0(f"Selected gulp of {gulp}")
     verbose_message0(f"Approx {nsamples // gulp} gulps (+1 if no samples cut off)")
     verbose_message1(f"The last {nsamp_cut_off} samples will be cut off")
@@ -794,7 +844,7 @@ if __name__ == "__main__":
 
     # precompute DM shifts
     # align it to the highest frequency channel
-    if fs[0] > fs [-1]:
+    if fs[0] > fs[-1]:
         fref = fs[0]
     else:
         fref = fs[-1]
@@ -840,20 +890,32 @@ if __name__ == "__main__":
     )
     verbose_message2("Read in first chunk")
     verbose_message3(f"Size of chunk: {sys.getsizeof(intensities)/1000/1000} MB")
-    verbose_message3(f"Approximate size of dedispersion arrays: {approx_size_shifted_arrays(intensities, maxDT)/1000/1000} MB")
-
+    verbose_message3(
+        f"Approximate size of dedispersion arrays: {approx_size_shifted_arrays(intensities, maxDT)/1000/1000} MB"
+    )
 
     # Process first gulp separately
     intensities[:, list(zerochans)] = 0
-    preprocess(intspergulp, ptsperint, intensities, running_dict, args.clipsig, args.droptotsig, gulp, maxDT, current_int, mask)
-    #verbose_message3("First gulp, initializing prev_array")
+    preprocess(
+        intspergulp,
+        ptsperint,
+        intensities,
+        running_dict,
+        args.clipsig,
+        args.droptotsig,
+        gulp,
+        maxDT,
+        current_int,
+        mask,
+    )
+    # verbose_message3("First gulp, initializing prev_array")
     prev_array = np.zeros((maxDT, nchans), dtype=intensities.dtype)
-    #verbose_message3(f"prev_array size {sys.getsizeof(prev_array)/1000/1000}MB")
+    # verbose_message3(f"prev_array size {sys.getsizeof(prev_array)/1000/1000}MB")
     prev_array, mid_array, end_array = shift_and_stack(
         intensities, shifts, prev_array, maxDT
     )
-    #verbose_message3(f"shifted and stacked first gulp")
-    #verbose_message3(f"array sizes: {sys.getsizeof(prev_array)/1000000}, {sys.getsizeof(mid_array)/1000000}, {sys.getsizeof(end_array)/1000000} MB")
+    # verbose_message3(f"shifted and stacked first gulp")
+    # verbose_message3(f"array sizes: {sys.getsizeof(prev_array)/1000000}, {sys.getsizeof(mid_array)/1000000}, {sys.getsizeof(end_array)/1000000} MB")
     outf.write(mid_array.ravel().astype(arr_outdtype))
 
     # reset for next loop
@@ -866,16 +928,27 @@ if __name__ == "__main__":
 
     # test if need to do next loop, or if on last gulp
     if intensities.shape[0] > maxDT:
-        if intensities.shape[0] < gulp: #  on last gulp
-            if (intensities.shape[0] % ptsperint):  # last int is weirdly sized
+        if intensities.shape[0] < gulp:  #  on last gulp
+            if intensities.shape[0] % ptsperint:  # last int is weirdly sized
                 intspergulp = (gulp // ptsperint) + 1
 
         while True:
-            #tt0 = time.perf_counter()
+            # tt0 = time.perf_counter()
             intensities[:, list(zerochans)] = 0
-            preprocess(intspergulp, ptsperint, intensities, running_dict, args.clipsig, args.droptotsig, gulp, maxDT, current_int, mask)
-            #tt1 = time.perf_counter()
-            #verbose_message3(f"Clipped and masked gulp {current_gulp} in {tt1 - tt0} s")
+            preprocess(
+                intspergulp,
+                ptsperint,
+                intensities,
+                running_dict,
+                args.clipsig,
+                args.droptotsig,
+                gulp,
+                maxDT,
+                current_int,
+                mask,
+            )
+            # tt1 = time.perf_counter()
+            # verbose_message3(f"Clipped and masked gulp {current_gulp} in {tt1 - tt0} s")
 
             # Brute-force dedisperse whole gulp
             prev_array, mid_array, end_array = shift_and_stack(
@@ -883,9 +956,9 @@ if __name__ == "__main__":
             )
             outf.write(prev_array.ravel().astype(arr_outdtype))
             outf.write(mid_array.ravel().astype(arr_outdtype))
-            #tt2 = time.perf_counter()
-            #verbose_message3(f"Dedispersed in {tt2-tt1} s")
-            #verbose_message1(f"Processed gulp {current_gulp}")
+            # tt2 = time.perf_counter()
+            # verbose_message3(f"Dedispersed in {tt2-tt1} s")
+            # verbose_message1(f"Processed gulp {current_gulp}")
             print(f"Processed gulp {current_gulp}")
             current_gulp += 1
 
@@ -901,7 +974,7 @@ if __name__ == "__main__":
             if intensities.shape[0] < gulp:
                 if intensities.size == 0 or intensities.shape[0] < maxDT:
                     break
-                elif (intensities.shape[0] % ptsperint):
+                elif intensities.shape[0] % ptsperint:
                     intspergulp = (gulp // ptsperint) + 1
 
     outf.close()

--- a/get_good_gulp.py
+++ b/get_good_gulp.py
@@ -15,8 +15,8 @@ t0 = time.perf_counter()
 def sizeof_fmt(num, use_kibibyte=False, dp=1):
     """Make number of bytes human-readable, default is 1kB = 1000B
     To use 1024, set use_kibibyte=True"""
-    base, suffix = [(1000.,'B'),(1024.,'iB')][use_kibibyte]
-    for x in ['B'] + list(map(lambda x: x+suffix, list('kMGTP'))):
+    base, suffix = [(1000.0, "B"), (1024.0, "iB")][use_kibibyte]
+    for x in ["B"] + list(map(lambda x: x + suffix, list("kMGTP"))):
         if -base < num < base:
             return f"{num:3.{dp}f} {x}"
         num /= base
@@ -26,17 +26,19 @@ def sizeof_fmt(num, use_kibibyte=False, dp=1):
 def factorize(num):
     return [n for n in range(1, num + 1) if num % n == 0]
 
+
 def DM_delay(DM, freq, *ref_freq):
     """
     Pass in DM (cm-3pc), freq (MHz), and optionally a reference frequency
     Returns time delay in seconds
     Uses Manchester-Taylor 1/2.4E-4 convention
     """
-    K = 1.0 / 2.41E-4  # Manchester-Taylor convention, units in MHz cm-3pc s
+    K = 1.0 / 2.41e-4  # Manchester-Taylor convention, units in MHz cm-3pc s
     if ref_freq:
-        return K * DM * (1/freq**2 - 1/ref_freq[0]**2)
+        return K * DM * (1 / freq**2 - 1 / ref_freq[0] ** 2)
     else:
         return K * DM / freq**2
+
 
 def inverse_DM_delay(delay_s, freq, *ref_freq):
     """Inverse of DM_delay
@@ -44,11 +46,12 @@ def inverse_DM_delay(delay_s, freq, *ref_freq):
     (if not included it's referenced to infinite frequency)
     Returns the DM which would produce that delay in cm-3pc
     Uses Manchester-Taylor 1/2.4E-4 convention"""
-    K = 1.0 / 2.41E-4  # Manchester-Taylor convention, units in MHz cm-3pc s
+    K = 1.0 / 2.41e-4  # Manchester-Taylor convention, units in MHz cm-3pc s
     if ref_freq:
-        return delay_s / (1/freq**2 - 1/ref_freq[0]**2) / K
+        return delay_s / (1 / freq**2 - 1 / ref_freq[0] ** 2) / K
     else:
         return delay_s * freq**2 / K
+
 
 def get_fs(fmin, fmax, nchans, type="center", **kwargs):
     """Get channel frequencies for a band with edges fmin, fmax
@@ -62,15 +65,21 @@ def get_fs(fmin, fmax, nchans, type="center", **kwargs):
     if type == "lower":
         return np.linspace(fmin, fmax, nchans, endpoint=False, **kwargs)
     if type == "center":
-        return np.linspace(fmin + df/2, fmax - df/2, nchans, endpoint=True, **kwargs)
+        return np.linspace(
+            fmin + df / 2, fmax - df / 2, nchans, endpoint=True, **kwargs
+        )
     if type == "upper":
         return np.linspace(fmin + df, fmax, nchans, endpoint=True, **kwargs)
     else:
-        raise AttributeError(f"type {type} not recognised, must be one of 'center', 'lower', 'upper'")
+        raise AttributeError(
+            f"type {type} not recognised, must be one of 'center', 'lower', 'upper'"
+        )
+
 
 def round_to_samples(delta_t, sampling_time):
     """Round a time delay to the nearest number of time samples"""
     return np.round(delta_t / sampling_time).astype(int)
+
 
 def zero_or_none(thing):
     """returns True if thing is 0/[]/""/etc or None
@@ -80,6 +89,7 @@ def zero_or_none(thing):
     else:
         return True
 
+
 def not_zero_or_none(thing):
     """returns False if thing is 0/[]/""/etc or None
     returns True for anything else, aka value isn't empty/0/None"""
@@ -88,10 +98,13 @@ def not_zero_or_none(thing):
     else:
         return False
 
+
 def check_positive_float(value):
     fvalue = float(value)
     if fvalue <= 0:
-        raise argparse.ArgumentTypeError("%s is an invalid positive float value" % value)
+        raise argparse.ArgumentTypeError(
+            "%s is an invalid positive float value" % value
+        )
     return fvalue
 
 
@@ -100,36 +113,64 @@ def check_positive_float(value):
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
-    description="""Give some info to choose a good gulp size for chunk_dedisperse"""
+    description="""Give some info to choose a good gulp size for chunk_dedisperse""",
 )
-parser.add_argument('filename', type=str,
-                    help='Filterbank file to dedisperse')
+parser.add_argument("filename", type=str, help="Filterbank file to dedisperse")
 
 g = parser.add_mutually_exclusive_group(required=True)
-g.add_argument('-d', '--dm', type=float, default=0,
-               help="DM (cm-3pc) to dedisperse to")
-g.add_argument('-t', '--maxdt', type=check_positive_float, default=0,
-               help="Number of time samples corresponding to the DM delay between the lowest and highest channel\n(must be positive)")
-
-parser.add_argument('--where_channel_ref', default='center', choices=['center', 'lower', 'upper'],
-                     help='Where within the channel ')
-
-parser.add_argument('-m', '--max', default=1E9, type=float, help="max number of bytes to allow")
-parser.add_argument('-f', '--fudge', default=1, type=float,
-    help=f"fudge factor for max bytes to allow\n"
-         f"aka if pass in 512E6 for max -> 512MB\n"
-         f"and pass in a fudge of 2\n"
-         f"it'll stop when 2 * estimated byte size > 512MB"
+g.add_argument("-d", "--dm", type=float, default=0, help="DM (cm-3pc) to dedisperse to")
+g.add_argument(
+    "-t",
+    "--maxdt",
+    type=check_positive_float,
+    default=0,
+    help="Number of time samples corresponding to the DM delay between the lowest and highest channel\n(must be positive)",
 )
-parser.add_argument('-l', '--last_only', action='store_true', help="only print last line (useful with <max>)")
 
-parser.add_argument('--fdmt', action='store_true', help="Get good gulp size for fdmt instead")
+parser.add_argument(
+    "--where_channel_ref",
+    default="center",
+    choices=["center", "lower", "upper"],
+    help="Where within the channel ",
+)
 
-parser.add_argument('--thin', action='store_true', help="Thin the output gulps to only the max and min, for that number of chunks, under the max size limit")
+parser.add_argument(
+    "-m", "--max", default=1e9, type=float, help="max number of bytes to allow"
+)
+parser.add_argument(
+    "-f",
+    "--fudge",
+    default=1,
+    type=float,
+    help=f"fudge factor for max bytes to allow\n"
+    f"aka if pass in 512E6 for max -> 512MB\n"
+    f"and pass in a fudge of 2\n"
+    f"it'll stop when 2 * estimated byte size > 512MB",
+)
+parser.add_argument(
+    "-l",
+    "--last_only",
+    action="store_true",
+    help="only print last line (useful with <max>)",
+)
 
-parser.add_argument('-v', '--verbosity', action='count', default=0)
+parser.add_argument(
+    "--fdmt", action="store_true", help="Get good gulp size for fdmt instead"
+)
 
-parser.add_argument('--tophalf', action='store_true', help="only use with --fdmt. Run on only top half of the band")
+parser.add_argument(
+    "--thin",
+    action="store_true",
+    help="Thin the output gulps to only the max and min, for that number of chunks, under the max size limit",
+)
+
+parser.add_argument("-v", "--verbosity", action="count", default=0)
+
+parser.add_argument(
+    "--tophalf",
+    action="store_true",
+    help="only use with --fdmt. Run on only top half of the band",
+)
 
 args = parser.parse_args()
 
@@ -140,7 +181,6 @@ filename = args.filename
 DM = args.dm
 maxDT = args.maxdt
 where_channel_ref_freq = args.where_channel_ref
-
 
 
 def verbose_message(verbosity_level, message):
@@ -165,10 +205,10 @@ nchans = header["nchans"]
 
 
 # calculate fmin and fmax FROM HEADER
-fmax = header["fch1"] - header["foff"]/2
+fmax = header["fch1"] - header["foff"] / 2
 fmin = fmax + nchans * header["foff"]
 if args.fdmt and args.tophalf:
-    fmin = fmin + (fmax-fmin)/2
+    fmin = fmin + (fmax - fmin) / 2
     nchans = nchans // 2
 verbose_message(2, f"fmin: {fmin}, fmax: {fmax}, nchans: {nchans} tsamp: {tsamp}")
 
@@ -179,6 +219,7 @@ verbose_message(2, f"fmin: {fmin}, fmax: {fmax}, nchans: {nchans} tsamp: {tsamp}
 
 if args.fdmt:
     from fdmt.cpu_fdmt import FDMT
+
     fs = np.linspace(fmin, fmax, nchans, endpoint=True)
 else:
     fs = get_fs(fmin, fmax, nchans, type=where_channel_ref_freq)
@@ -198,20 +239,24 @@ else:
 verbose_message(1, f"Max DM is {DM}")
 verbose_message(1, f"Maximum DM delay need to shift by is {maxdelay_s} s")
 verbose_message(1, f"This corresponds to {maxDT} time samples")
-print(f"Minimum gulp size is {maxDT}")  # I think mid_array being 0 size won't break anything? Don't know how the write handles that
+print(
+    f"Minimum gulp size is {maxDT}"
+)  # I think mid_array being 0 size won't break anything? Don't know how the write handles that
 
 if args.fdmt:
     fd1 = FDMT(fmin=fmin, fmax=fmax, nchan=nchans, maxDT=maxDT)
 
 # OLD: based on factors of nsamples
-#factors = np.array(factorize(nsamples))
-#factors_over_maxDT = factors[factors > maxDT]
-#possible_gulps = factors_over_maxDT
-#verbose_message(1, f"\ngulps > maxDT ({maxDT}) which are also factors of nsamples ({nsamples}): \n{factors_over_maxDT}")
+# factors = np.array(factorize(nsamples))
+# factors_over_maxDT = factors[factors > maxDT]
+# possible_gulps = factors_over_maxDT
+# verbose_message(1, f"\ngulps > maxDT ({maxDT}) which are also factors of nsamples ({nsamples}): \n{factors_over_maxDT}")
 
 # NEW: what actually want is for all gulps to be > maxDT
 print(f"Number of samples: {nsamples}")
-gulps_over_maxDT = np.arange(maxDT+1, nsamples) # haven't tested whether it throws a hissy fit if gulp=maxDT, so being safe
+gulps_over_maxDT = np.arange(
+    maxDT + 1, nsamples
+)  # haven't tested whether it throws a hissy fit if gulp=maxDT, so being safe
 leftovers = nsamples % gulps_over_maxDT
 no_leftovers = gulps_over_maxDT[leftovers == 0]
 no_data_lost = gulps_over_maxDT[leftovers > maxDT]
@@ -221,17 +266,25 @@ possible_gulps.sort()
 left = [nsamples % g for g in possible_gulps]
 
 
-verbose_message(1, "Memory size below is an approximation and based on the size of the main arrays for the calculation")
-#verbose_message(1, "(Based on very minimal testing on a small observation!) it can be 2x this")
+verbose_message(
+    1,
+    "Memory size below is an approximation and based on the size of the main arrays for the calculation",
+)
+# verbose_message(1, "(Based on very minimal testing on a small observation!) it can be 2x this")
 
 print("")
-print(f"{'gulp':<20} {'nchunks':<10} {'approx size':<14} {'x1.25':<10} {'x1.5':<10} {'x2':<10}")
-nbytes = header['nbits'] // 8
+print(
+    f"{'gulp':<20} {'nchunks':<10} {'approx size':<14} {'x1.25':<10} {'x1.5':<10} {'x2':<10}"
+)
+nbytes = header["nbits"] // 8
 if nbytes < 4:
-    verbose_message(0, f"WARNING {nbytes} bytes used for size estimation BUT if using a mask everyhing gets converted to floats - times by {int(4/nbytes)}")
-#prev = []
+    verbose_message(
+        0,
+        f"WARNING {nbytes} bytes used for size estimation BUT if using a mask everyhing gets converted to floats - times by {int(4/nbytes)}",
+    )
+# prev = []
 
-dt = [('gulp', int), ('nchunks', int), ('leftover', int), ('byte_size_data', float)]
+dt = [("gulp", int), ("nchunks", int), ("leftover", int), ("byte_size_data", float)]
 data = []
 for i in range(len(possible_gulps)):
     gulp = possible_gulps[i]
@@ -239,46 +292,56 @@ for i in range(len(possible_gulps)):
     nchunks = int(nsamples / gulp)
 
     if args.fdmt:
-        byte_size_intensities = gulp*nchans*nbytes
-        byte_size_prev_arr = maxDT*maxDT*nbytes
+        byte_size_intensities = gulp * nchans * nbytes
+        byte_size_prev_arr = maxDT * maxDT * nbytes
 
         numRowsA = (fd1.subDT(fd1.fs)).sum()
         numRowsB = (fd1.subDT(fd1.fs[::2], fd1.fs[2] - fd1.fs[0])).sum()
-        byte_size_A = (gulp + 2*maxDT)*numRowsA*nbytes
-        byte_size_B = (gulp + 2*maxDT)*numRowsB*nbytes
+        byte_size_A = (gulp + 2 * maxDT) * numRowsA * nbytes
+        byte_size_B = (gulp + 2 * maxDT) * numRowsB * nbytes
 
-        byte_size_data = byte_size_A + byte_size_B + byte_size_intensities + byte_size_prev_arr
+        byte_size_data = (
+            byte_size_A + byte_size_B + byte_size_intensities + byte_size_prev_arr
+        )
 
     else:
-        byte_size_data = (2*gulp*nchans + maxDT*nchans)*nbytes
+        byte_size_data = (2 * gulp * nchans + maxDT * nchans) * nbytes
 
     data.append((gulp, nchunks, leftover, byte_size_data))
 gulps_and_info = np.array(data, dtype=dt)
 
-within_size_lim = gulps_and_info[gulps_and_info['byte_size_data'] * args.fudge <= args.max]
+within_size_lim = gulps_and_info[
+    gulps_and_info["byte_size_data"] * args.fudge <= args.max
+]
 
-prec=2
+prec = 2
 
 if args.last_only:
     gulp, nchunks, leftover, byte_size_data = within_size_lim[-1]
-    print(f"{gulp:<20} {nchunks:<10} {sizeof_fmt(byte_size_data, dp=prec):<14} "
-          f"{sizeof_fmt(1.25*byte_size_data, dp=prec):<10} "
-          f"{sizeof_fmt(1.5*byte_size_data, dp=prec):<10} "
-          f"{sizeof_fmt(2*byte_size_data, dp=prec):<10}")
+    print(
+        f"{gulp:<20} {nchunks:<10} {sizeof_fmt(byte_size_data, dp=prec):<14} "
+        f"{sizeof_fmt(1.25*byte_size_data, dp=prec):<10} "
+        f"{sizeof_fmt(1.5*byte_size_data, dp=prec):<10} "
+        f"{sizeof_fmt(2*byte_size_data, dp=prec):<10}"
+    )
 elif args.thin:
-    for nchunk in np.unique(within_size_lim['nchunks'])[::-1]:
-        same_nchunk = within_size_lim[within_size_lim['nchunks'] == nchunk]
-        mingulp_idx = np.where(same_nchunk['gulp'] == same_nchunk['gulp'].min())[0]
-        maxgulp_idx = np.where(same_nchunk['gulp'] == same_nchunk['gulp'].max())[0]
+    for nchunk in np.unique(within_size_lim["nchunks"])[::-1]:
+        same_nchunk = within_size_lim[within_size_lim["nchunks"] == nchunk]
+        mingulp_idx = np.where(same_nchunk["gulp"] == same_nchunk["gulp"].min())[0]
+        maxgulp_idx = np.where(same_nchunk["gulp"] == same_nchunk["gulp"].max())[0]
         for id in [mingulp_idx, maxgulp_idx]:
             gulp, nchunks, leftover, byte_size_data = same_nchunk[id][0]
-            print(f"{gulp:<20} {nchunks:<10} {sizeof_fmt(byte_size_data, dp=prec):<14} "
-                  f"{sizeof_fmt(1.25*byte_size_data, dp=prec):<10} "
-                  f"{sizeof_fmt(1.5*byte_size_data, dp=prec):<10} "
-                  f"{sizeof_fmt(2*byte_size_data, dp=prec):<10}")
+            print(
+                f"{gulp:<20} {nchunks:<10} {sizeof_fmt(byte_size_data, dp=prec):<14} "
+                f"{sizeof_fmt(1.25*byte_size_data, dp=prec):<10} "
+                f"{sizeof_fmt(1.5*byte_size_data, dp=prec):<10} "
+                f"{sizeof_fmt(2*byte_size_data, dp=prec):<10}"
+            )
 else:
     for (gulp, nchunks, leftover, byte_size_data) in within_size_lim:
-        print(f"{gulp:<20} {nchunks:<10} {sizeof_fmt(byte_size_data, dp=prec):<14} "
-              f"{sizeof_fmt(1.25*byte_size_data, dp=prec):<10} "
-              f"{sizeof_fmt(1.5*byte_size_data, dp=prec):<10} "
-              f"{sizeof_fmt(2*byte_size_data, dp=prec):<10}")
+        print(
+            f"{gulp:<20} {nchunks:<10} {sizeof_fmt(byte_size_data, dp=prec):<14} "
+            f"{sizeof_fmt(1.25*byte_size_data, dp=prec):<10} "
+            f"{sizeof_fmt(1.5*byte_size_data, dp=prec):<10} "
+            f"{sizeof_fmt(2*byte_size_data, dp=prec):<10}"
+        )


### PR DESCRIPTION
Adds masking, clipping, and per-channel clipping (for CHIME filterbank dropped packets) before dedispersion.  

I think also some structural changes.  

And maybe changes to get_good_gulp so it now works better in general and better for FDMT gulps.  