### PR TITLE
chunk_dedisperse.get_gulp: put ceiling on gulp

### DIFF
--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -492,7 +492,7 @@ def get_gulp(nsamples, ptsperint, maxDT, mingulp, desired_gulp, maxoverfac=1.5):
             raise RuntimeError(
                 f"No possible gulp sizes found between mingulp ({mingulp}) and maxoverfac*desired_gulp ({maxoverfac}*{desired_gulp}={maxoverfac*desired_gulp})"
             )
-        logging.debug(f"{ipg_over_maxDT.size} gulps found between mingulp ({mingulp}) and maxoverfac*desired_gulp ({maxoverfac}*{desired_gulp}={maxoverfac*desired_gulp}):\n{ipg_over_maxDT}")
+        logging.debug(f"{ipg_over_maxDT.size} gulps found between mingulp ({mingulp}) and maxoverfac*desired_gulp ({maxoverfac}*{desired_gulp}={maxoverfac*desired_gulp}):\n{ipg_over_maxDT*ptsperint}")
 
         # number of time samples in final read
         leftovers = np.array([nsamples % (ptsperint * ipg) for ipg in ipg_over_maxDT])

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -452,7 +452,17 @@ def approx_size_shifted_arrays(data, maxDT):
     return 2 * prev_sz + mid_sz + end_sz
 
 
-def get_gulp(nsamples, ptsperint, maxDT, mingulp, desired_gulp):
+def get_gulp(nsamples, ptsperint, maxDT, mingulp, desired_gulp, maxoverfac=1.5):
+    """
+    Get a compatible gulp size.
+    Must be a multiple of ptsperint
+    
+    The last intake will likely be fewer samples than the gulp. If this is less than maxDT then it gets cutt off
+    This function therefore tries to choose a gulp near to the desired_gulp for which the last intake is >maxDT
+
+    maxoverfac assumes that the desired_gulp is motivated by RAM and going too far above it will cause an OOM
+    gulps greater than maxoverfac * desired_gulp will not be considered
+    """
     if mingulp == 0:  # DM = 0 case
         gulp = (int(desired_gulp // ptsperint) + 1) * ptsperint
         return gulp, 0
@@ -475,6 +485,14 @@ def get_gulp(nsamples, ptsperint, maxDT, mingulp, desired_gulp):
             raise RuntimeError(
                 f"No possible gulp sizes over mingulp in {all_intspergulp*ptsperint}"
             )
+        
+        # cut off anything over maxoverfac * desired_gulp
+        ipg_over_maxDT = ipg_over_maxDT[ipg_over_maxDT < maxoverfac*desired_gulp]
+        if ipg_over_maxDT.size == 0:
+            raise RuntimeError(
+                f"No possible gulp sizes found between mingulp ({mingulp}) and maxoverfac*desired_gulp ({maxoverfac}*{desired_gulp}={maxoverfac*desired_gulp})"
+            )
+        logging.debug(f"{ipg_over_maxDT.size} gulps found between mingulp ({mingulp}) and maxoverfac*desired_gulp ({maxoverfac}*{desired_gulp}={maxoverfac*desired_gulp}):\n{ipg_over_maxDT}")
 
         # number of time samples in final read
         leftovers = np.array([nsamples % (ptsperint * ipg) for ipg in ipg_over_maxDT])

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -487,7 +487,7 @@ def get_gulp(nsamples, ptsperint, maxDT, mingulp, desired_gulp, maxoverfac=1.5):
             )
         
         # cut off anything over maxoverfac * desired_gulp
-        ipg_over_maxDT = ipg_over_maxDT[ipg_over_maxDT < maxoverfac*desired_gulp]
+        ipg_over_maxDT = ipg_over_maxDT[ipg_over_maxDT < maxoverfac*desired_gulp/ptsperint]
         if ipg_over_maxDT.size == 0:
             raise RuntimeError(
                 f"No possible gulp sizes found between mingulp ({mingulp}) and maxoverfac*desired_gulp ({maxoverfac}*{desired_gulp}={maxoverfac*desired_gulp})"


### PR DESCRIPTION
Added `maxoverfac=1.5` to `get_gulp` so it won't consider any gulps over `maxoverfac*desired_gulp` as an option.  

Why:  
In special cases end up with way too giant a gulp and job OOMs
Thus far seen it happen when:
- file is an exact multiple of the rfifind ptsperint. In that case gulp options are limited to factors of nsamples/ptsperint, which can be very large and far from the gulp passed in. This usually happens because it's a test file or the last half is rubbish so I grabbed a subsection of the whole original file.
- the ptsperint is high. The chunk_dedisperse gulp has to be a multiple of ptsperint, and `get_gulp` first tries to preserve all the data and not cut any off at the end (which it will if the last bit is < maxDT) this can lead to it choosing higher factors of ptsperint than I'd like

Would rather a) not pick that large a gulp in the first place and b) it exit and give a more helpful error message than an OOM if the only options for a gulp are huge


