### PR TITLE
Dedispersion fixes

### DIFF
--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -271,7 +271,7 @@ def clip(
             ] = chan_running_avg  # this edits intensities in place, might want to change
 
     # debugging
-    extra_stuff_to_return = [numgoodpts, running_avg, running_std, current_avg, current_std, chan_running_avg, chan_avg_temp]
+    extra_stuff_to_return = []  #numgoodpts, running_avg, running_std, current_avg, current_std, chan_running_avg, chan_avg_temp]
 
     # CHIME dropped-packet clipping
     if not_zero_or_none(droptot_sig):
@@ -322,14 +322,14 @@ def clip_mask_subbase_gulp(
 
     # debugging
     # initialise extra stuff:
-    nchan = data.shape[-1]
-    numgoodpts = np.zeros((nint), dtype=int) 
-    running_avg = np.zeros((nint), dtype=float)
-    running_std = np.zeros((nint), dtype=float)
-    current_avg = np.zeros((nint), dtype=float)
-    current_std = np.zeros((nint), dtype=float)
-    chan_running_avg = np.zeros((nint, nchan), dtype=float) 
-    chan_avg_temp = np.zeros((nint, nchan), dtype=float)
+    #nchan = data.shape[-1]
+    #numgoodpts = np.zeros((nint), dtype=int) 
+    #running_avg = np.zeros((nint), dtype=float)
+    #running_std = np.zeros((nint), dtype=float)
+    #current_avg = np.zeros((nint), dtype=float)
+    #current_std = np.zeros((nint), dtype=float)
+    #chan_running_avg = np.zeros((nint, nchan), dtype=float) 
+    #chan_avg_temp = np.zeros((nint, nchan), dtype=float)
 
     for interval in range(nint):
         slc = get_slice(data, interval, ptsperint, gulp, maxDT)
@@ -345,8 +345,8 @@ def clip_mask_subbase_gulp(
         data[slc, zap_chans] = running_dict["chan_running_avg"][zap_chans]
 
         logging.debug(f"data mean for block before clip: {data[slc, :].mean()}")
-        data[slc, :], running_dict, numgoodpts[interval], running_avg[interval], running_std[interval], current_avg[interval], current_std[interval], chan_running_avg[interval,:], chan_avg_temp[interval,:] = clip(
-        #data[slc, :], running_dict= clip(
+        #data[slc, :], running_dict, numgoodpts[interval], running_avg[interval], running_std[interval], current_avg[interval], current_std[interval], chan_running_avg[interval,:], chan_avg_temp[interval,:] = clip(
+        data[slc, :], running_dict= clip(
             data[slc, :],
             clipsig,
             ignorechans=ign,
@@ -356,14 +356,14 @@ def clip_mask_subbase_gulp(
         if current_int in mask.mask_zap_ints:
             logging.debug(f"chan_running_avg after:\n{running_dict['chan_running_avg']}")
             logging.debug(f"same everywhere? {np.isclose(running_dict['chan_running_avg'], tmp).all()}")
-        logging.debug(f"interval:{interval}, numgoodpts:{numgoodpts[interval]}")
+        #logging.debug(f"interval:{interval}, numgoodpts:{numgoodpts[interval]}")
 
         if subbase:
             data[slc, :] -= running_dict["chan_running_avg"]
 
         current_int += 1
         logging.debug(f"data mean for block after clip: {data[slc, :].mean()}")
-    return running_dict, current_int, numgoodpts, running_avg, running_std, current_avg, current_std, chan_running_avg, chan_avg_temp
+    return running_dict, current_int  #, numgoodpts, running_avg, running_std, current_avg, current_std, chan_running_avg, chan_avg_temp
 
 
 def clip_subbase_gulp(
@@ -384,14 +384,14 @@ def clip_subbase_gulp(
 
     # debugging
     # initialise extra stuff:
-    nchan = data.shape[-1]
-    numgoodpts = np.zeros((nint), dtype=int) 
-    running_avg = np.zeros((nint), dtype=float)
-    running_std = np.zeros((nint), dtype=float)
-    current_avg = np.zeros((nint), dtype=float)
-    current_std = np.zeros((nint), dtype=float)
-    chan_running_avg = np.zeros((nint, nchan), dtype=float) 
-    chan_avg_temp = np.zeros((nint, nchan), dtype=float)
+    #nchan = data.shape[-1]
+    #numgoodpts = np.zeros((nint), dtype=int) 
+    #running_avg = np.zeros((nint), dtype=float)
+    #running_std = np.zeros((nint), dtype=float)
+    #current_avg = np.zeros((nint), dtype=float)
+    #current_std = np.zeros((nint), dtype=float)
+    #chan_running_avg = np.zeros((nint, nchan), dtype=float) 
+    #chan_avg_temp = np.zeros((nint, nchan), dtype=float)
 
     logging.debug(f"clip: nint:{nint}")
     for interval in range(nint):
@@ -399,20 +399,20 @@ def clip_subbase_gulp(
         slc = get_slice(data, interval, ptsperint, gulp, maxDT)
 
         logging.debug(f"data mean for block before clip: {data[slc, :].mean()}")
-        data[slc, :], running_dict, numgoodpts[interval], running_avg[interval], running_std[interval], current_avg[interval], current_std[interval], chan_running_avg[interval,:], chan_avg_temp[interval,:]  = clip(
-        #data[slc, :], running_dict = clip(
+        #data[slc, :], running_dict, numgoodpts[interval], running_avg[interval], running_std[interval], current_avg[interval], current_std[interval], chan_running_avg[interval,:], chan_avg_temp[interval,:]  = clip(
+        data[slc, :], running_dict = clip(
             data[slc, :],
             clipsig,
             droptot_sig=droptotsig,
             **running_dict,
         )
-        logging.debug(f"interval:{interval}, numgoodpts:{numgoodpts[interval]}")
+        #logging.debug(f"interval:{interval}, numgoodpts:{numgoodpts[interval]}")
 
         if subbase:
             data[slc, :] -= running_dict["chan_running_avg"]
         current_int += 1
         logging.debug(f"data mean for block after clip: {data[slc, :].mean()}")
-    return running_dict, current_int, numgoodpts, running_avg, running_std, current_avg, current_std, chan_running_avg, chan_avg_temp
+    return running_dict, current_int  #, numgoodpts, running_avg, running_std, current_avg, current_std, chan_running_avg, chan_avg_temp
 
 
 ################################################################################
@@ -995,19 +995,19 @@ if __name__ == "__main__":
 
     # debugging
     # initialise extra stuff
-    numgoodpts = np.zeros((nints_tot), dtype=int) 
-    running_avg = np.zeros((nints_tot), dtype=float) 
-    running_std = np.zeros_like(running_avg) 
-    current_avg = np.zeros_like(running_avg)
-    current_std = np.zeros_like(running_avg)
-    chan_running_avg = np.zeros((nints_tot, nchans), dtype=float)
-    chan_avg_temp = np.zeros_like(chan_running_avg)
+    #numgoodpts = np.zeros((nints_tot), dtype=int) 
+    #running_avg = np.zeros((nints_tot), dtype=float) 
+    #running_std = np.zeros_like(running_avg) 
+    #current_avg = np.zeros_like(running_avg)
+    #current_std = np.zeros_like(running_avg)
+    #chan_running_avg = np.zeros((nints_tot, nchans), dtype=float)
+    #chan_avg_temp = np.zeros_like(chan_running_avg)
 
     # Process first gulp separately
     intensities[:, list(zerochans)] = 0
     logging.debug(f"pre first gulp running_dict:\n{running_dict}")
-    running_dict, current_int, numgoodpts[:intspergulp], running_avg[:intspergulp], running_std[:intspergulp], current_avg[:intspergulp], current_std[:intspergulp], chan_running_avg[:intspergulp,:], chan_avg_temp[:intspergulp,:] = preprocess(
-    #running_dict, current_int = preprocess(
+    #running_dict, current_int, numgoodpts[:intspergulp], running_avg[:intspergulp], running_std[:intspergulp], current_avg[:intspergulp], current_std[:intspergulp], chan_running_avg[:intspergulp,:], chan_avg_temp[:intspergulp,:] = preprocess(
+    running_dict, current_int = preprocess(
         intspergulp,
         ptsperint,
         intensities,
@@ -1059,8 +1059,8 @@ if __name__ == "__main__":
             int_slc = slice(intspergulp_norm*current_gulp, intspergulp_norm*current_gulp + intspergulp)
             logging.debug(f"int_slic is from {intspergulp_norm*current_gulp} to {intspergulp_norm*current_gulp + intspergulp}")
             logging.debug(f"pre {current_gulp} gulp running_dict:\n{running_dict}")
-            running_dict, current_int, numgoodpts[int_slc], running_avg[int_slc], running_std[int_slc], current_avg[int_slc], current_std[int_slc], chan_running_avg[int_slc,:], chan_avg_temp[int_slc,:] = preprocess(
-            #running_dict, current_int = preprocess(
+            #running_dict, current_int, numgoodpts[int_slc], running_avg[int_slc], running_std[int_slc], current_avg[int_slc], current_std[int_slc], chan_running_avg[int_slc,:], chan_avg_temp[int_slc,:] = preprocess(
+            running_dict, current_int = preprocess(
                 intspergulp,
                 ptsperint,
                 intensities,
@@ -1117,8 +1117,8 @@ if __name__ == "__main__":
     filfile.close()
 
     # debugging, write more things
-    logging.info(f"Writing running averages etc for debugging to {out_filename[:-4]}_chunk_dedsip_debug_stats.npz")
-    np.savez(os.path.join(args.outdir, "{out_filename[:-4]}_chunk_dedsip_debug_stats.npz"), numgoodpts=numgoodpts, running_avg=running_avg, running_std=running_std, current_avg=current_avg, current_std=current_std, chan_running_avg=chan_running_avg, chan_avg_temp=chan_avg_temp)
+    #logging.info(f"Writing running averages etc for debugging to {out_filename[:-4]}_chunk_dedsip_debug_stats.npz")
+    #np.savez(os.path.join(args.outdir, "{out_filename[:-4]}_chunk_dedsip_debug_stats.npz"), numgoodpts=numgoodpts, running_avg=running_avg, running_std=running_std, current_avg=current_avg, current_std=current_std, chan_running_avg=chan_running_avg, chan_avg_temp=chan_avg_temp)
 
     t2 = time.perf_counter()
 

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -631,6 +631,12 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--subbase",
+        action='store_true',
+        help="Subtract the (moving) mean from each channel as you go. NB the mean is updated every rfifnd interval so this may lead to discontinuities in data",
+    )
+
+    parser.add_argument(
         "-v",
         "--verbose",
         help="Increase logging level to debug",
@@ -672,8 +678,10 @@ if __name__ == "__main__":
     if args.clipsig or args.droptotsig or args.mask:
         if not_zero_or_none(args.mask):
             logging.info(
-                "Preprocess is: clipping/computing running averages, subtracting baseline, masking"
+                "Preprocess is: clipping/computing running averages, masking"
             )
+            if args.subbase:
+                logging.info("Preprocess will also subtract a per-channel, per-rfifind-interval baseline")
 
             def preprocess(*args, **kwargs):
                 clip_mask_subbase_gulp(*args, **kwargs)
@@ -682,6 +690,9 @@ if __name__ == "__main__":
             logging.info(
                 "Preprocess is: clipping/computing running averages, subtracting baseline, NOT masking"
             )
+
+            if args.subbase:
+                logging.info("Preprocess will also subtract a per-channel, per-rfifind-interval baseline")
 
             def preprocess(*args, **kwargs):
                 clip_subbase_gulp(*args, **kwargs)
@@ -904,6 +915,7 @@ if __name__ == "__main__":
         maxDT,
         current_int,
         mask,
+        subbase=args.subbase,
     )
     logging.debug("First gulp, initializing prev_array")
     prev_array = np.zeros((maxDT, nchans), dtype=intensities.dtype)
@@ -945,6 +957,7 @@ if __name__ == "__main__":
                 maxDT,
                 current_int,
                 mask,
+                subbase=args.subbase,
             )
             # tt1 = time.perf_counter()
             # logging.debug(f"Clipped and masked gulp {current_gulp} in {tt1 - tt0} s")

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -275,6 +275,7 @@ def clip_mask_subbase_gulp(
     maxDT,
     current_int,
     mask,
+    subbase=True,
 ):
     """Clip, mask and subtract the running_avg from a gulp"""
     for interval in range(nint):
@@ -298,8 +299,10 @@ def clip_mask_subbase_gulp(
                 **running_dict,
             )
 
-        data[slc, :] -= running_dict["chan_running_avg"]
-        data[slc, list(mask.mask_zap_chans_per_int[current_int])] = 0
+        data[slc, list(mask.mask_zap_chans_per_int[current_int])] = running_dict["chan_running_avg"][list(mask.mask_zap_chans_per_int[current_int])]
+        if subbase:
+            data[slc, :] -= running_dict["chan_running_avg"]
+
         current_int += 1
 
 
@@ -313,7 +316,8 @@ def clip_subbase_gulp(
     gulp,
     maxDT,
     current_int,
-    *args,
+    mask,
+    subbase=True,
 ):
     """Same as clip_mask_subbase_gulp but no mask"""
     for interval in range(nint):
@@ -337,7 +341,8 @@ def clip_subbase_gulp(
                 **running_dict,
             )
 
-        data[slc, :] -= running_dict["chan_running_avg"]
+        if subbase:
+            data[slc, :] -= running_dict["chan_running_avg"]
         current_int += 1
 
 

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -132,7 +132,7 @@ class Mask:
 
         # get first unmasked mean for each channel
         self.first_unmasked_avg = np.zeros(self.nchan, dtype=float)
-        for c in range(nchan):
+        for c in range(self.nchan):
             if c in self.mask_zap_chans:
                 self.first_unmasked_avg[c] = 0
             else:

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -382,6 +382,7 @@ def clip_subbase_gulp(
             clipsig,
             droptot_sig=droptotsig,
             **running_dict,
+        )
         logging.debug(f"interval:{interval}, numgoodpts:{numgoodpts[interval]}")
 
         if subbase:

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -10,6 +10,8 @@ import sys, os
 import logging
 from gen_utils import handle_exception
 
+from matplotlib import pyplot as plt
+
 ################################################################################
 ############################ DEFINE FUNCTIONS ETC ##############################
 
@@ -234,6 +236,13 @@ def clip(
         chan_running_std = chan_std_temp  # for CHIME dropped-packet clipping
         if current_avg == 0:
             logging.warning("Warning: problem with clipping in first block!!!\n\n")
+        # diagnostic to check not over-clipping
+        plt.plot(intensities)
+        plt.axhline(lo_cutoff)
+        plt.axhline(hi_cutoff)
+        plt.axhline(current_med)
+        plt.savefig("clipping_first_block_diagnostic.png")
+        plt.close()
 
     # See if any points need clipping
     if not_zero_or_none(clip_sigma):

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -332,7 +332,9 @@ def clip_subbase_gulp(
     subbase=True,
 ):
     """Same as clip_mask_subbase_gulp but no mask"""
+    logging.debug(f"clip: subbase={subbase}")
     for interval in range(nint):
+        logging.debug(f"data mean for block before clip: {data[slc, :].mean()}")
         try:
             slc = slice(interval * ptsperint, (interval + 1) * ptsperint)
             data[slc, :], running_dict = clip(
@@ -356,6 +358,7 @@ def clip_subbase_gulp(
         if subbase:
             data[slc, :] -= running_dict["chan_running_avg"]
         current_int += 1
+        logging.debug(f"data mean for block after clip: {data[slc, :].mean()}")
 
 
 ################################################################################
@@ -678,6 +681,8 @@ if __name__ == "__main__":
 
     # log unhandled exception
     sys.excepthook = handle_exception
+
+    logging.debug(f"args:\n{args}")
 
     t0 = time.perf_counter()
 

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -280,14 +280,14 @@ def clip(
 
 def get_slice(data, interval, ptsperint, gulp, maxDT):
     try:
-            slc = slice(interval * ptsperint, (interval + 1) * ptsperint)
-            tmp = data[slc,0].sum()  # throwaway to test the slice
-            del tmp
-        except IndexError:  # in case on leftover partial-interval 
-            logging.debug(
-                f"Last interval detected: length {data.shape[0]} where gulp is {gulp} and maxDT {maxDT}",
-            )
-            slc = slice(interval * ptsperint, None)
+        slc = slice(interval * ptsperint, (interval + 1) * ptsperint)
+        tmp = data[slc,0].sum()  # throwaway to test the slice
+        del tmp
+    except IndexError:  # in case on leftover partial-interval 
+        logging.debug(
+            f"Last interval detected: length {data.shape[0]} where gulp is {gulp} and maxDT {maxDT}",
+        )
+        slc = slice(interval * ptsperint, None)
     return slc
 
 

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -10,8 +10,6 @@ import sys, os
 import logging
 from gen_utils import handle_exception
 
-from matplotlib import pyplot as plt
-
 ################################################################################
 ############################ DEFINE FUNCTIONS ETC ##############################
 

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -1103,11 +1103,14 @@ if __name__ == "__main__":
             if intensities.shape[0] < gulp:
                 if intensities.size == 0 or intensities.shape[0] < maxDT:
                     break
-                elif intensities.shape[0] % ptsperint:
-                    intspergulp = (intensities.shape[0] // ptsperint) + 1
-                    logging.debug(
-                        f"last gulp detected, intspergulp changed to {intspergulp}"
-                    )
+                else:
+                    logging.info("On last gulp")
+                    logging.debug(f"intensities.shape[0]// ptsperint: {intensities.shape[0]// ptsperint}")
+                    intspergulp = int(intensities.shape[0]// ptsperint)
+                    if intensities.shape[0] % ptsperint:  # last int is weirdly sized
+                        intspergulp += 1
+                        logging.debug(f"intspergulp changed to {intspergulp}")
+                    logging.info(f"intspergulp: {intspergulp}")
 
     outf.close()
     #outfdm0.close()

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -292,9 +292,9 @@ def clip_mask_subbase_gulp(
     """Clip, mask and subtract the running_avg from a gulp"""
     logging.debug(f"clip: subbase={subbase}")
     for interval in range(nint):
-        logging.debug(f"data mean for block before clip: {data[slc, :].mean()}")
         try:
             slc = slice(interval * ptsperint, (interval + 1) * ptsperint)
+            logging.debug(f"data mean for block before clip: {data[slc, :].mean()}")
             data[slc, :], running_dict = clip(
                 data[slc, :],
                 clipsig,
@@ -337,9 +337,9 @@ def clip_subbase_gulp(
     """Same as clip_mask_subbase_gulp but no mask"""
     logging.debug(f"clip: subbase={subbase}")
     for interval in range(nint):
-        logging.debug(f"data mean for block before clip: {data[slc, :].mean()}")
         try:
             slc = slice(interval * ptsperint, (interval + 1) * ptsperint)
+            logging.debug(f"data mean for block before clip: {data[slc, :].mean()}")
             data[slc, :], running_dict = clip(
                 data[slc, :],
                 clipsig,

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -971,9 +971,9 @@ if __name__ == "__main__":
     out_filename = args.filename[:-4] + f"_DM{DM:.{dmprec}f}.fil"
     outf = open(os.path.join(args.outdir, out_filename), "wb")
 
-    out_filename_0dm = args.filename[:-4] + f"_DM{DM:.{dmprec}f}_DM0.dat"
-    logging.debug(f"Writing dm0 dat to {out_filename_0dm}")
-    outfdm0 = open(os.path.join(args.outdir, out_filename_0dm), "wb")
+    #out_filename_0dm = args.filename[:-4] + f"_DM{DM:.{dmprec}f}_DM0.dat"
+    #logging.debug(f"Writing dm0 dat to {out_filename_0dm}")
+    #outfdm0 = open(os.path.join(args.outdir, out_filename_0dm), "wb")
 
     logging.info(f"Writing header to {out_filename}\n")
     write_header(header, outf)
@@ -1032,7 +1032,7 @@ if __name__ == "__main__":
     logging.info(f"shifted and stacked first gulp")
     logging.info(f"array sizes: {sys.getsizeof(prev_array)/1000000}, {sys.getsizeof(mid_array)/1000000}, {sys.getsizeof(end_array)/1000000} MB")
     outf.write(mid_array.ravel().astype(arr_outdtype))
-    outfdm0.write(mid_array.sum(axis=-1).astype(arr_outdtype))
+    #outfdm0.write(mid_array.sum(axis=-1).astype(arr_outdtype))
     current_gulp += 1
 
     # reset for next loop
@@ -1085,8 +1085,8 @@ if __name__ == "__main__":
             )
             outf.write(prev_array.ravel().astype(arr_outdtype))
             outf.write(mid_array.ravel().astype(arr_outdtype))
-            outfdm0.write(prev_array.sum(axis=-1).astype(arr_outdtype))
-            outfdm0.write(mid_array.sum(axis=-1).astype(arr_outdtype))
+            #outfdm0.write(prev_array.sum(axis=-1).astype(arr_outdtype))
+            #outfdm0.write(mid_array.sum(axis=-1).astype(arr_outdtype))
             # tt2 = time.perf_counter()
             # logging.debug(f"Dedispersed in {tt2-tt1} s")
             # logging.debug(f"Processed gulp {current_gulp}")
@@ -1112,7 +1112,7 @@ if __name__ == "__main__":
                     )
 
     outf.close()
-    outfdm0.close()
+    #outfdm0.close()
     filfile.close()
 
     # debugging, write more things

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -202,6 +202,15 @@ def clip(
     hi_cutoff = current_med + 3.0 * current_std
     chan_avg_temp = np.zeros((numchan))
 
+    if first_block:
+        # diagnostic to check not over-clipping
+        plt.plot(intensities)
+        plt.axhline(lo_cutoff)
+        plt.axhline(hi_cutoff)
+        plt.axhline(current_med)
+        plt.savefig("clipping_first_block_diagnostic.png")
+        plt.close()
+
     # Find the "good" points
     good_pts_idx = np.where(
         (zero_dm_time_series > lo_cutoff) & (zero_dm_time_series < hi_cutoff)
@@ -236,13 +245,7 @@ def clip(
         chan_running_std = chan_std_temp  # for CHIME dropped-packet clipping
         if current_avg == 0:
             logging.warning("Warning: problem with clipping in first block!!!\n\n")
-        # diagnostic to check not over-clipping
-        plt.plot(intensities)
-        plt.axhline(lo_cutoff)
-        plt.axhline(hi_cutoff)
-        plt.axhline(current_med)
-        plt.savefig("clipping_first_block_diagnostic.png")
-        plt.close()
+
 
     # See if any points need clipping
     if not_zero_or_none(clip_sigma):

--- a/chunk_dedisperse.py
+++ b/chunk_dedisperse.py
@@ -290,7 +290,9 @@ def clip_mask_subbase_gulp(
     subbase=True,
 ):
     """Clip, mask and subtract the running_avg from a gulp"""
+    logging.debug(f"clip: subbase={subbase}")
     for interval in range(nint):
+        logging.debug(f"data mean for block before clip: {data[slc, :].mean()}")
         try:
             slc = slice(interval * ptsperint, (interval + 1) * ptsperint)
             data[slc, :], running_dict = clip(
@@ -316,6 +318,7 @@ def clip_mask_subbase_gulp(
             data[slc, :] -= running_dict["chan_running_avg"]
 
         current_int += 1
+        logging.debug(f"data mean for block after clip: {data[slc, :].mean()}")
 
 
 def clip_subbase_gulp(

--- a/chunk_fdmt_fb2bin.py
+++ b/chunk_fdmt_fb2bin.py
@@ -256,7 +256,7 @@ if invertband:
         """Read in next gulp and prep it to feed into fdmt"""
         data = np.fromfile(filfile, count=gulp * nchans, dtype=arr_dtype).reshape(
             -1, nchans
-        )
+        ).astype(np.float32)
         return data[:, read_inv_slc].T
 
 else:
@@ -266,7 +266,7 @@ else:
         """Read in next gulp and prep it to feed into fdmt"""
         data = np.fromfile(filfile, count=gulp * nchans, dtype=arr_dtype).reshape(
             -1, nchans
-        )
+        ).astype(np.float32)
         return data[:, read_slc].T
 
 


### PR DESCRIPTION
With more rfi zapping discovered many weird things going on with dedispersion.

Major changes/fixes:
- `current_int` was not carrying over between gulps so incorrect portion of the mask was being used
- likewise `chan_running_avg` was being reset each gulp
- the masking was done in such a way that bad intervals would affect the running averages
- the last gulp wasn't quite handled properly, there was a case that slipped through the logic
- made subtracting the baseline optional AND made the default not o subtract it
- fdmt now casts to `np.float32` when it reads in data

Some other small things, and a bunch of debugging messages. Also can now uncomment some stuff and track the running averages etc as the code runs and write them out at the end