### PR TITLE
Add rfipipeline checks, fix downsampling overflow, minor sigproc_utils

### DIFF
--- a/downsample_fil_nosigpyproc.py
+++ b/downsample_fil_nosigpyproc.py
@@ -14,8 +14,12 @@ def downsample_fil(fname, downsamps, gulp, sum_arr=False):
     arr_dtype = get_dtype(header["nbits"])
 
     if header['nbits'] < 32 and sum_arr:
-        print(f"Note, as tscrunching and native dtype of the filterbank is {arr_dtype}, it will be converted and written as np.float32")
-        out_dtype = np.float32
+        if header['nbits'] == 8:
+            print(f"Note, as tscrunching and native dtype of the filterbank is {arr_dtype}, it will be converted and written as np.uint16")
+            out_dtype = np.uint16
+        else:
+            print(f"Note, as tscrunching and native dtype of the filterbank is {arr_dtype}, it will be converted and written as np.float32")
+            out_dtype = np.float32
     else:
         out_dtype = arr_dtype
 
@@ -75,7 +79,7 @@ def downsample_fil(fname, downsamps, gulp, sum_arr=False):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Downsample a file (using sigpyproc3)")
+    parser = argparse.ArgumentParser(description="Downsample a file")
 
     parser.add_argument("filename", type=str, help="Sigproc filterbank file")
     parser.add_argument(
@@ -94,7 +98,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tscrunch",
         action='store_true',
-        help="If true then sum <downsamp> elements together. Otherwise only use every <downsamp> element"
+        help="If true then sum <downsamp> elements together. Otherwise only use every <downsamp> element. Data is converted to float32 to do the sum. If native dytpe was uint8 it'll be written as uint16 to avoid overflows, else float32"
     )
 
     args = parser.parse_args()

--- a/fix_dropped_packets_nopresto.py
+++ b/fix_dropped_packets_nopresto.py
@@ -20,6 +20,11 @@
 # is detectable via this method
 # to overcome this also mask +-<fdp_tscrunch> time samples either side of masked range
 
+# realized with uint8 I'm probably hitting overflow errors with the tscrunching
+# already factored that into the stats stuff
+# and np.add.reduce changes the dtype if there isn't sufficient precision
+# But my write for the tscrunched fils was definitely overflowing
+
 # add logging
 # add handle_exception
 
@@ -228,6 +233,15 @@ if  __name__ == "__main__":
     nchans = header["nchans"]
     arr_dtype = get_dtype(header["nbits"])
 
+    # make tscrunch_dtype if need it
+    if header["nbits"] == 8:
+        tscrunch_dtype =  np.uint16
+    elif header["nbits"] == 16:
+        tscrunch_dtype = np.float32  # ths one probably isn't necessary, but maybe?
+    else:
+        tscrunch_dtype = arr_dtype
+
+
     if header["nifs"] != 1:
         raise AttributeError(f"Code not written to deal with unsummed polarization data")
 
@@ -345,7 +359,7 @@ if  __name__ == "__main__":
         if additional_fils:
             for ii, d in enumerate(args.downsamp):
                 scrunched_arr =  tscrunch(spec, d)
-                additional_fils[ii].write(scrunched_arr.ravel().astype(arr_dtype))
+                additional_fils[ii].write(scrunched_arr.ravel().astype(tscrunch_dtype))
                 del scrunched_arr
 
         # calc stats

--- a/fix_dropped_packets_nopresto.py
+++ b/fix_dropped_packets_nopresto.py
@@ -292,6 +292,7 @@ if  __name__ == "__main__":
             additional_fils.append(open(add_fn, "wb"))
             add_header = copy.deepcopy(header)
             add_header["tsamp"] = header["tsamp"] * d
+            add_header["nbits"] = get_nbits(tscrunch_dtype)
             if header.get("nsamples", ""):
                 add_header["nsamples"] = int(header["nsamples"] // d)
             write_header(add_header, additional_fils[i])

--- a/rfi_pipeline.py
+++ b/rfi_pipeline.py
@@ -890,6 +890,10 @@ def check_mask_and_continue(old_mask, old_mask_exstats, add_mask, add_mask_exsta
         logging.warning(f"{stage}: completely zaps {zap_int_frac} of the intervals, this probably indicates a problem, plotting summary and exiting")
         logging.info(f"{stage}: working msk unchanged")
         make_summary_plots(add_mask, add_mask_exstats, rfimask, means, var, pdf, title_insert=f"ERROR stage {stage}")
+        if pdf is not None:
+            logging.info("Writing pdf")
+            pdf.close()
+        logging.info("Done")
         sys.exit(1)
         return old_mask, old_mask_exstats
     else:

--- a/rfi_pipeline.py
+++ b/rfi_pipeline.py
@@ -880,8 +880,14 @@ def check_mask_and_continue(old_mask, old_mask_exstats, add_mask, add_mask_exsta
     
     """
     zap_frac = masked_frac(old_mask | add_mask)
+    zap_int_frac = len(get_ignoreints_from_mask(old_mask | add_mask)) / old_mask.shape[0]
     if  zap_frac >= threshold:
         logging.warning(f"{stage}: zaps {zap_frac} of data, which is over the problem threshold, plotting summary and skipping")
+        logging.info(f"{stage}: working maask unchanged")
+        make_summary_plots(add_mask, add_mask_exstats, rfimask, means, var, pdf, title_insert=f"ERROR stage {stage}")
+        return old_mask, old_mask_exstats
+    elif zap_int_frac >= 0.3:  # could prob put this lower
+        logging.warning(f"{stage}: completely zaps {zap_int_frac} of the intervals, this probably indicates a problem, plotting summary and skipping")
         logging.info(f"{stage}: working maask unchanged")
         make_summary_plots(add_mask, add_mask_exstats, rfimask, means, var, pdf, title_insert=f"ERROR stage {stage}")
         return old_mask, old_mask_exstats

--- a/rfi_pipeline.py
+++ b/rfi_pipeline.py
@@ -883,12 +883,12 @@ def check_mask_and_continue(old_mask, old_mask_exstats, add_mask, add_mask_exsta
     zap_int_frac = len(get_ignoreints_from_mask(old_mask | add_mask)) / old_mask.shape[0]
     if  zap_frac >= threshold:
         logging.warning(f"{stage}: zaps {zap_frac} of data, which is over the problem threshold, plotting summary and skipping")
-        logging.info(f"{stage}: working maask unchanged")
+        logging.info(f"{stage}: working mask unchanged")
         make_summary_plots(add_mask, add_mask_exstats, rfimask, means, var, pdf, title_insert=f"ERROR stage {stage}")
         return old_mask, old_mask_exstats
     elif zap_int_frac >= 0.3:  # could prob put this lower
         logging.warning(f"{stage}: completely zaps {zap_int_frac} of the intervals, this probably indicates a problem, plotting summary and exiting")
-        logging.info(f"{stage}: working maask unchanged")
+        logging.info(f"{stage}: working msk unchanged")
         make_summary_plots(add_mask, add_mask_exstats, rfimask, means, var, pdf, title_insert=f"ERROR stage {stage}")
         sys.exit(1)
         return old_mask, old_mask_exstats

--- a/rfi_pipeline.py
+++ b/rfi_pipeline.py
@@ -887,9 +887,10 @@ def check_mask_and_continue(old_mask, old_mask_exstats, add_mask, add_mask_exsta
         make_summary_plots(add_mask, add_mask_exstats, rfimask, means, var, pdf, title_insert=f"ERROR stage {stage}")
         return old_mask, old_mask_exstats
     elif zap_int_frac >= 0.3:  # could prob put this lower
-        logging.warning(f"{stage}: completely zaps {zap_int_frac} of the intervals, this probably indicates a problem, plotting summary and skipping")
+        logging.warning(f"{stage}: completely zaps {zap_int_frac} of the intervals, this probably indicates a problem, plotting summary and exiting")
         logging.info(f"{stage}: working maask unchanged")
         make_summary_plots(add_mask, add_mask_exstats, rfimask, means, var, pdf, title_insert=f"ERROR stage {stage}")
+        sys.exit(1)
         return old_mask, old_mask_exstats
     else:
         logging.info(f"{stage}: zaps {zap_frac} of data (change = {zap_frac - masked_frac(old_mask)})")

--- a/rfi_pipeline.py
+++ b/rfi_pipeline.py
@@ -1573,7 +1573,7 @@ parser.add_argument(
 parser.add_argument(
     "--problem_frac",
     type=float,
-    default=0.7,
+    default=0.6,
     help="If masking fraction goes above this threshold then there is a problem, skip whatever step did this"
 )
 

--- a/sigproc_utils.py
+++ b/sigproc_utils.py
@@ -46,6 +46,12 @@ def get_nbits(dtype):
         raise RuntimeError(f"dtype={dtype} not supported")
 
 
+def try_remove(item, alist):
+    try:
+        alist.remove(item)
+    except ValueError:
+        pass
+
 # OK so if it's a filterbank it SHOULD have HEADER_START and HEADER_END
 # I think I was testing it on one that wasn't properly written, so I had to
 # add them in
@@ -90,3 +96,9 @@ def get_fmin_fmax_invert(header):
         invert = False
 
     return fmin, fmax, invert
+
+def get_lowest_freq_channel(header):
+    """Calculate central freq of lowest freq channel"""
+    fmin, fmax, invert = get_fmin_fmax_invert(header)
+    flo = fmin + abs(header["foff"])/2
+    return flo


### PR DESCRIPTION
Was getting that weird RFI corrupting a ton of an obs and then the pipeline continued happily along.
So I added a thing that checks for:
 - a large chunk of consecutive intervals being zapped (default is 60s)
 - checks if the fraction of intervals zapped is too high (>0.3, harcoded) this was my first attempt but didn't catch everything, hopefully now obsolete due to first bullet, but leaving in just in case
 I also changed the default problem fraction (for all data masked) to 0.6 from 0.7

I realised that as I now tscrunch instead of downsampling I'm definitely overflowing uint8. Fixed so that the data type is changed to uint16. Also if input was uint16 it's changed to float32. Assuming float32 won't overflow since the max value is pretty large.

Noticed try_remove function was missing in sigproc_utils. It shouldn't get used since I think the need for it stemmed from me incorrectly writing filterbank headers during testing aaaages ago, but added it for completeness.

Added  convenience function get_lowest_freq_channel to get the central freq of the lowest-freq channel